### PR TITLE
Adds concept of additional bucket policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply. We recommend `private` to avoid exposing sensitive information | string | `private` | no |
-| additional_bucket_policies | Set this to a list of strings container valid JSON policy statements if you want to add arbitrary additions to the bucket policy | list | `<list>` | no |
+| additional_bucket_policies | Set this to a list of strings containing valid JSON policy statements if you want to add arbitrary additions to the bucket policy | list | `<list>` | no |
 | allow_encrypted_uploads_only | Set to `true` to prevent uploads of unencrypted objects to S3 bucket | string | `false` | no |
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply. We recommend `private` to avoid exposing sensitive information | string | `private` | no |
+| additional_bucket_policies | Set this to a list of strings container valid JSON policy statements if you want to add arbitrary additions to the bucket policy | list | `<list>` | no |
 | allow_encrypted_uploads_only | Set to `true` to prevent uploads of unencrypted objects to S3 bucket | string | `false` | no |
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply. We recommend `private` to avoid exposing sensitive information | string | `private` | no |
-| additional_bucket_policies | Set this to a list of strings container valid JSON policy statements if you want to add arbitrary additions to the bucket policy | list | `<list>` | no |
+| additional_bucket_policies | Set this to a list of strings containing valid JSON policy statements if you want to add arbitrary additions to the bucket policy | list | `<list>` | no |
 | allow_encrypted_uploads_only | Set to `true` to prevent uploads of unencrypted objects to S3 bucket | string | `false` | no |
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,6 +3,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply. We recommend `private` to avoid exposing sensitive information | string | `private` | no |
+| additional_bucket_policies | Set this to a list of strings container valid JSON policy statements if you want to add arbitrary additions to the bucket policy | list | `<list>` | no |
 | allow_encrypted_uploads_only | Set to `true` to prevent uploads of unencrypted objects to S3 bucket | string | `false` | no |
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ module "aggregated_policy" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count  = "${(var.enabled == "true" && var.allow_encrypted_uploads_only == "true") || length(var.additional_bucket_policies) > 0 ? 1 : 0}"
+  count  = "${var.enabled == "true" && (var.allow_encrypted_uploads_only == "true" || length(var.additional_bucket_policies) > 0) ? 1 : 0}"
   bucket = "${join("", aws_s3_bucket.default.*.id)}"
 
   policy = "${module.aggregated_policy.result_document}"

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "bucket_policy" {
 }
 
 module "aggregated_policy" {
-  source = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
+  source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = "${flatten(list(data.aws_iam_policy_document.bucket_policy.*.json, var.additional_bucket_policies))}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -88,8 +88,6 @@ data "aws_iam_policy_document" "bucket_policy" {
 }
 
 module "aggregated_policy" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-
   source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = "${flatten(list(data.aws_iam_policy_document.bucket_policy.*.json, var.additional_bucket_policies))}"
 }
@@ -98,5 +96,5 @@ resource "aws_s3_bucket_policy" "default" {
   count = "${var.enabled == "true" && (var.allow_encrypted_uploads_only == "true" || length(var.additional_bucket_policies) > 0) ? 1 : 0}"
 
   bucket = "${join("", aws_s3_bucket.default.*.id)}"
-  policy = "${join("", module.aggregated_policy.*.result_document)}"
+  policy = "${module.aggregated_policy.result_document}"
 }

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,8 @@ data "aws_iam_policy_document" "bucket_policy" {
 }
 
 module "aggregated_policy" {
+  count = "${var.enabled == "true" ? 1 : 0}"
+
   source           = "git::https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator.git?ref=tags/0.1.2"
   source_documents = "${flatten(list(data.aws_iam_policy_document.bucket_policy.*.json, var.additional_bucket_policies))}"
 }
@@ -96,5 +98,5 @@ resource "aws_s3_bucket_policy" "default" {
   count  = "${var.enabled == "true" && (var.allow_encrypted_uploads_only == "true" || length(var.additional_bucket_policies) > 0) ? 1 : 0}"
   bucket = "${join("", aws_s3_bucket.default.*.id)}"
 
-  policy = "${module.aggregated_policy.result_document}"
+  policy = "${join("", module.aggregated_policy.*.result_document)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -95,8 +95,8 @@ module "aggregated_policy" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count  = "${var.enabled == "true" && (var.allow_encrypted_uploads_only == "true" || length(var.additional_bucket_policies) > 0) ? 1 : 0}"
-  bucket = "${join("", aws_s3_bucket.default.*.id)}"
+  count = "${var.enabled == "true" && (var.allow_encrypted_uploads_only == "true" || length(var.additional_bucket_policies) > 0) ? 1 : 0}"
 
+  bucket = "${join("", aws_s3_bucket.default.*.id)}"
   policy = "${join("", module.aggregated_policy.*.result_document)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -100,5 +100,5 @@ variable "allow_encrypted_uploads_only" {
 variable "additional_bucket_policies" {
   type        = "list"
   default     = []
-  description = "Set this to a list of strings container valid JSON policy statements if you want to add arbitrary additions to the bucket policy"
+  description = "Set this to a list of strings containing valid JSON policy statements if you want to add arbitrary additions to the bucket policy"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,9 @@ variable "allow_encrypted_uploads_only" {
   default     = "false"
   description = "Set to `true` to prevent uploads of unencrypted objects to S3 bucket"
 }
+
+variable "additional_bucket_policies" {
+  type        = "list"
+  default     = []
+  description = "Set this to a list of strings container valid JSON policy statements if you want to add arbitrary additions to the bucket policy"
+}


### PR DESCRIPTION
## What

This allows a user of this module to specify additional arbitrary policies they would like to apply to the bucket.

## Why

Currently, the `allow_encrypted_uploads_only` option uses the only attachment available for bucket policies on the s3 bucket.  If a user needs to add their own policies, say to enable cross account access to the bucket, they cannot.  This allows them to do that.

## Example usage
```
data "aws_iam_policy_document" "additional_policies" {
  count = "${length(var.trusted_roles) > 0 ? 1 : 0}"

  statement {
    effect = "Allow"
    principals = {
      type = "AWS"
      identifiers = "${var.trusted_roles}"
    }

    actions = [
      "s3:Get*",
      "s3:Put*",
      "s3:List*"
    ]

    resources = [
      "${module.s3_bucket.bucket_arn}"
    ]
  }
}

module "s3_bucket" {
  source                       = "git::https://github.com/asiegman/terraform-aws-s3-bucket.git?ref=moar-bucket-policy-0.11"
  enabled                      = "true"
  versioning_enabled           = "true"
  kms_master_key_arn           = "${module.my_kms_key.key_arn}"
  sse_algorithm                = "aws:kms"
  allow_encrypted_uploads_only = "true"
  name                         = "${var.name}"
  stage                        = "${var.stage}"
  namespace                    = "${var.namespace}"
  additional_bucket_policies   = ["${data.aws_iam_policy_document.additional_policies.*.json}"]
}
```

## Example Output:
```
# Cleaned up and redacted new policy output from terraform plan
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "DenyIncorrectEncryptionHeader",
      "Effect": "Deny",
      "Action": "s3:PutObject",
      "Resource": "arn:aws:s3:::example-staging-example/*",
      "Principal": "*",
      "Condition": {
        "StringNotEquals": {
          "s3:x-amz-server-side-encryption": [
            "aws:kms"
          ]
        }
      }
    },
    {
      "Sid": "DenyUnEncryptedObjectUploads",
      "Effect": "Deny",
      "Action": "s3:PutObject",
      "Resource": "arn:aws:s3:::example-staging-example/*",
      "Principal": "*",
      "Condition": {
        "Null": {
          "s3:x-amz-server-side-encryption": [
            "true"
          ]
        }
      }
    },
    {
      "Sid": "",
      "Effect": "Allow",
      "Action": [
        "s3:Put*",
        "s3:List*",
        "s3:Get*"
      ],
      "Resource": "arn:aws:s3:::example-staging-example",
      "Principal": {
        "AWS": "arn:aws:iam::331539668475:role/example-x-account-server-role"
      }
    }
  ]
}
```