### PR TITLE
Adds ability to block public access ACLs and Policies on the created S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Available targets:
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
+| enable_block_public_access | Enables blocking all public access capabilities to the created bucket. | bool | `false` | no |
 | enable_glacier_transition | Enables the transition to AWS Glacier which can cause unnecessary costs for huge amount of small files | bool | `true` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -8,6 +8,7 @@
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
+| enable_block_public_access | Enables blocking all public access capabilities to the created bucket. | bool | `false` | no |
 | enable_glacier_transition | Enables the transition to AWS Glacier which can cause unnecessary costs for huge amount of small files | bool | `true` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -134,3 +134,11 @@ resource "aws_s3_bucket_policy" "default" {
   bucket = join("", aws_s3_bucket.default.*.id)
   policy = join("", data.aws_iam_policy_document.bucket_policy.*.json)
 }
+
+resource "aws_s3_bucket_public_access_block" "default" {
+  count = var.enable_block_public_access ? 1 : 0
+
+  bucket              = join("", aws_s3_bucket.default.*.id)
+  block_public_acls   = true
+  block_public_policy = true
+}

--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,9 @@ resource "aws_s3_bucket_policy" "default" {
 resource "aws_s3_bucket_public_access_block" "default" {
   count = var.enable_block_public_access ? 1 : 0
 
-  bucket              = join("", aws_s3_bucket.default.*.id)
-  block_public_acls   = true
-  block_public_policy = true
+  bucket                  = join("", aws_s3_bucket.default.*.id)
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -166,3 +166,8 @@ variable "lifecycle_tags" {
   default     = {}
 }
 
+variable "enable_block_public_access" {
+  type        = bool
+  description = "Enables blocking all public access capabilities to the created bucket."
+  default     = false
+}


### PR DESCRIPTION
## Info

Adds usage of the [aws_s3_bucket_public_access_block](https://www.terraform.io/docs/providers/aws/r/s3_bucket_public_access_block.html) resource to disallow public access policies and ACLs on the created bucket. Adds flag variable `enable_block_public_access` to control usage of that resource. 