### PR TITLE
Optionally allow public access to the bucket, default is now to block

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ This basic IAM system user is suitable for CI/CD systems (_e.g._ TravisCI, Circl
 
 We do not recommend creating IAM users this way for any other purpose.
 
+It blocks public access to the bucket by default.
+https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
 
 ---
 
@@ -128,6 +131,8 @@ Available targets:
 | allow_encrypted_uploads_only | Set to `true` to prevent uploads of unencrypted objects to S3 bucket | bool | `false` | no |
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| block_public_acls | Set to `false` to disable the blocking of new public access lists on the bucket | bool | `true` | no |
+| block_public_policy | Set to `false` to disable the blocking of new public policies on the bucket | bool | `true` | no |
 | cors_rule_inputs | Specifies the allowed headers, methods, origins and exposed headers when using CORS on this bucket | object | `null` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | enable_glacier_transition | Enables the transition to AWS Glacier which can cause unnecessary costs for huge amount of small files | bool | `true` | no |
@@ -137,6 +142,7 @@ Available targets:
 | expiration_days | Number of days after which to expunge the objects | number | `90` | no |
 | force_destroy | A boolean string that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | bool | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | number | `60` | no |
+| ignore_public_acls | Set to `false` to disable the ignoring of public access lists on the bucket | bool | `true` | no |
 | kms_master_key_arn | The AWS KMS master key ARN used for the `SSE-KMS` encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default aws/s3 AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms` | string | `` | no |
 | lifecycle_rule_enabled | Enable or disable lifecycle rule | bool | `false` | no |
 | lifecycle_tags | Tags filter. Used to manage object lifecycle events | map(string) | `<map>` | no |
@@ -147,6 +153,7 @@ Available targets:
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy | string | `` | no |
 | prefix | Prefix identifying one or more objects to which the rule applies | string | `` | no |
 | region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee | string | `` | no |
+| restrict_public_buckets | Set to `false` to disable the restricting of making the bucket public | bool | `true` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms` | string | `AES256` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
 | standard_transition_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | number | `30` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -73,6 +73,9 @@ description: |-
 
   We do not recommend creating IAM users this way for any other purpose.
 
+  It blocks public access to the bucket by default.
+  https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
 # How to use this project
 usage: |-
   ```hcl

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,8 @@
 | allow_encrypted_uploads_only | Set to `true` to prevent uploads of unencrypted objects to S3 bucket | bool | `false` | no |
 | allowed_bucket_actions | List of actions the user is permitted to perform on the S3 bucket | list(string) | `<list>` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
+| block_public_acls | Set to `false` to disable the blocking of new public access lists on the bucket | bool | `true` | no |
+| block_public_policy | Set to `false` to disable the blocking of new public policies on the bucket | bool | `true` | no |
 | cors_rule_inputs | Specifies the allowed headers, methods, origins and exposed headers when using CORS on this bucket | object | `null` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
 | enable_glacier_transition | Enables the transition to AWS Glacier which can cause unnecessary costs for huge amount of small files | bool | `true` | no |
@@ -16,6 +18,7 @@
 | expiration_days | Number of days after which to expunge the objects | number | `90` | no |
 | force_destroy | A boolean string that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | bool | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | number | `60` | no |
+| ignore_public_acls | Set to `false` to disable the ignoring of public access lists on the bucket | bool | `true` | no |
 | kms_master_key_arn | The AWS KMS master key ARN used for the `SSE-KMS` encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default aws/s3 AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms` | string | `` | no |
 | lifecycle_rule_enabled | Enable or disable lifecycle rule | bool | `false` | no |
 | lifecycle_tags | Tags filter. Used to manage object lifecycle events | map(string) | `<map>` | no |
@@ -26,6 +29,7 @@
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy | string | `` | no |
 | prefix | Prefix identifying one or more objects to which the rule applies | string | `` | no |
 | region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee | string | `` | no |
+| restrict_public_buckets | Set to `false` to disable the restricting of making the bucket public | bool | `true` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms` | string | `AES256` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | string | `` | no |
 | standard_transition_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | number | `30` | no |

--- a/main.tf
+++ b/main.tf
@@ -146,9 +146,10 @@ data "aws_iam_policy_document" "bucket_policy" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count  = var.enabled && var.allow_encrypted_uploads_only ? 1 : 0
-  bucket = join("", aws_s3_bucket.default.*.id)
-  policy = join("", data.aws_iam_policy_document.bucket_policy.*.json)
+  count      = var.enabled && var.allow_encrypted_uploads_only ? 1 : 0
+  bucket     = join("", aws_s3_bucket.default.*.id)
+  policy     = join("", data.aws_iam_policy_document.bucket_policy.*.json)
+  depends_on = [aws_s3_bucket_public_access_block.default]
 }
 
 # Refer to the terraform documentation on s3_bucket_public_access_block at

--- a/main.tf
+++ b/main.tf
@@ -150,3 +150,16 @@ resource "aws_s3_bucket_policy" "default" {
   bucket = join("", aws_s3_bucket.default.*.id)
   policy = join("", data.aws_iam_policy_document.bucket_policy.*.json)
 }
+
+# Refer to the terraform documentation on s3_bucket_public_access_block at
+# https://www.terraform.io/docs/providers/aws/r/s3_bucket_public_access_block.html
+# for the nuances of the blocking options
+resource "aws_s3_bucket_public_access_block" "default" {
+  count  = var.enabled ? 1 : 0
+  bucket = join("", aws_s3_bucket.default.*.id)
+
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
+}

--- a/variables.tf
+++ b/variables.tf
@@ -184,3 +184,27 @@ variable "lifecycle_tags" {
   description = "Tags filter. Used to manage object lifecycle events"
   default     = {}
 }
+
+variable "block_public_acls" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the blocking of new public access lists on the bucket"
+}
+
+variable "block_public_policy" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the blocking of new public policies on the bucket"
+}
+
+variable "ignore_public_acls" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the ignoring of public access lists on the bucket"
+}
+
+variable "restrict_public_buckets" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the restricting of making the bucket public"
+}


### PR DESCRIPTION
This will change the default behavior to now block public access to the bucket.  All options can be configured.  

This mirrors a recent update to the https://github.com/cloudposse/terraform-aws-s3-log-storage module.

This also supersedes https://github.com/cloudposse/terraform-aws-s3-bucket/pull/23