### PR TITLE
update AWS provider pinning to v3 for TF 0.13 version compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,13 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 
@@ -152,7 +153,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -210,6 +211,7 @@ Available targets:
 | user\_name | Normalized IAM user name |
 | user\_unique\_id | The user unique ID assigned by AWS |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| terraform | >= 0.12.0 |
+| aws | >= 2.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 
@@ -11,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -69,3 +70,4 @@
 | user\_name | Normalized IAM user name |
 | user\_unique\_id | The user unique ID assigned by AWS |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws   = ">= 3.0"
+    aws   = ">= 2.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 3.0"
+    aws   = ">= 3.0, < 4.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
+    aws   = "~> 3.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws   = ">= 3.0, < 4.0"
+    aws   = ">= 3.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }


### PR DESCRIPTION
## what
do not restrict the aws provider version to just v2

## why
https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/issues/23
the aws cloud provider has v13 fixes and requirements also

## references
`closes #46`
https://github.com/cloudposse/terraform-aws-s3-bucket/issues/46
