### PR TITLE
Remove hardcoded ARN partition information

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -210,6 +211,7 @@ Available targets:
 | user\_name | Normalized IAM user name |
 | user\_unique\_id | The user unique ID assigned by AWS |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -69,3 +70,4 @@
 | user\_name | Normalized IAM user name |
 | user\_unique\_id | The user unique ID assigned by AWS |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,8 @@ module "s3_user" {
   s3_resources = ["${join("", aws_s3_bucket.default.*.arn)}/*", join("", aws_s3_bucket.default.*.arn)]
 }
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "bucket_policy" {
   count = var.enabled && var.allow_encrypted_uploads_only ? 1 : 0
 
@@ -121,7 +123,7 @@ data "aws_iam_policy_document" "bucket_policy" {
     sid       = "DenyIncorrectEncryptionHeader"
     effect    = "Deny"
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${join("", aws_s3_bucket.default.*.id)}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${join("", aws_s3_bucket.default.*.id)}/*"]
 
     principals {
       identifiers = ["*"]
@@ -139,7 +141,7 @@ data "aws_iam_policy_document" "bucket_policy" {
     sid       = "DenyUnEncryptedObjectUploads"
     effect    = "Deny"
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${join("", aws_s3_bucket.default.*.id)}/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${join("", aws_s3_bucket.default.*.id)}/*"]
 
     principals {
       identifiers = ["*"]


### PR DESCRIPTION
This change will allow us to seamlessly support other AWS partitions
such as aws-us-gov.

## what
* Support other AWS partitions (such as aws-us-gov).
* This change is a NOOP for existing resources.

## why
* The module hardcodes the partition component of the ARN, making it impossible to use this module in other partitions.

## references
* See Amazon ARN [syntax](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax)

