### PR TITLE
Policy to allow only ssl uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Available targets:
 | abort\_incomplete\_multipart\_upload\_days | Maximum time (in days) that you want to allow multipart uploads to remain in progress | `number` | `5` | no |
 | acl | The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. We recommend `private` to avoid exposing sensitive information. Conflicts with `grants`. | `string` | `"private"` | no |
 | allow\_encrypted\_uploads\_only | Set to `true` to prevent uploads of unencrypted objects to S3 bucket | `bool` | `false` | no |
+| allow\_ssl\_requests\_only | Set to `true` to require requests to use Secure Socket Layer (HTTPS/SSL). This will explicitly deny access to HTTP requests | `bool` | `false` | no |
 | allowed\_bucket\_actions | List of actions the user is permitted to perform on the S3 bucket | `list(string)` | <pre>[<br>  "s3:PutObject",<br>  "s3:PutObjectAcl",<br>  "s3:GetObject",<br>  "s3:DeleteObject",<br>  "s3:ListBucket",<br>  "s3:ListBucketMultipartUploads",<br>  "s3:GetBucketLocation",<br>  "s3:AbortMultipartUpload"<br>]</pre> | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | block\_public\_acls | Set to `false` to disable the blocking of new public access lists on the bucket | `bool` | `true` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,12 @@ variable "allow_encrypted_uploads_only" {
   description = "Set to `true` to prevent uploads of unencrypted objects to S3 bucket"
 }
 
+variable "allow_ssl_requests_only" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to require requests to use Secure Socket Layer (HTTPS/SSL). This will explicitly deny access to HTTP requests"
+}
+
 variable "lifecycle_rule_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Adds enable flag to allow only ssl/https bucket uploads.
* Includes logic to merge other policies enabled by the user such as the string policy passed in via the `policy` variable and the other encryption policy. This prevents overriding the user defined policy (mentioned in issue #11) as long as the `sid` values are distinct.

## why
* Provides compliance with AWS Config rule s3-bucket-ssl-requests-only.
* Fixes an outstanding issues which prevents users from specifying their own policy string and enabling userful policies pre-defined within the module.

## references
* https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/
* https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html
* Closes #11

