### PR TITLE
use minimum versions for provider pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 2.0 |
+| aws | >= 3.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
 
@@ -153,7 +153,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 
@@ -203,6 +203,7 @@ Available targets:
 | bucket\_arn | Bucket ARN |
 | bucket\_domain\_name | FQDN of bucket |
 | bucket\_id | Bucket Name (aka ID) |
+| bucket\_region | Bucket region |
 | bucket\_regional\_domain\_name | The bucket region-specific domain name |
 | enabled | Is module enabled |
 | secret\_access\_key | The secret access key. This will be written to the state file in plain-text |

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Available targets:
 |------|---------|
 | terraform | >= 0.12.0 |
 | aws | >= 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,8 +5,8 @@
 |------|---------|
 | terraform | >= 0.12.0 |
 | aws | >= 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 2.0 |
+| aws | >= 3.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
 
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 
@@ -62,6 +62,7 @@
 | bucket\_arn | Bucket ARN |
 | bucket\_domain\_name | FQDN of bucket |
 | bucket\_id | Bucket Name (aka ID) |
+| bucket\_region | Bucket region |
 | bucket\_regional\_domain\_name | The bucket region-specific domain name |
 | enabled | Is module enabled |
 | secret\_access\_key | The secret access key. This will be written to the state file in plain-text |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,7 +7,6 @@ module "s3_bucket" {
 
   enabled                      = true
   user_enabled                 = true
-  region                       = var.region
   namespace                    = var.namespace
   stage                        = var.stage
   name                         = var.name

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -13,6 +13,11 @@ output "bucket_arn" {
   description = "Bucket ARN"
 }
 
+output "bucket_region" {
+  value       = module.s3_bucket.bucket_region
+  description = "Bucket region"
+}
+
 output "user_name" {
   value       = module.s3_bucket.user_name
   description = "Normalized IAM user name"

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,6 @@ resource "aws_s3_bucket" "default" {
   count         = var.enabled ? 1 : 0
   bucket        = module.label.id
   acl           = try(length(var.grants), 0) == 0 ? var.acl : null
-  region        = var.region
   force_destroy = var.force_destroy
   policy        = var.policy
   tags          = module.label.tags

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 module "s3_user" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-iam-s3-user.git?ref=tags/010.0"
+  source       = "git::https://github.com/cloudposse/terraform-aws-iam-s3-user.git?ref=tags/0.10.0"
   namespace    = var.namespace
   stage        = var.stage
   environment  = var.environment

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 module "s3_user" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-iam-s3-user.git?ref=tags/0.9.0"
+  source       = "git::https://github.com/cloudposse/terraform-aws-iam-s3-user.git?ref=tags/010.0"
   namespace    = var.namespace
   stage        = var.stage
   environment  = var.environment

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 module "s3_user" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-iam-s3-user.git?ref=tags/0.10.0"
+  source       = "git::https://github.com/cloudposse/terraform-aws-iam-s3-user.git?ref=tags/0.10.1"
   namespace    = var.namespace
   stage        = var.stage
   environment  = var.environment

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "bucket_arn" {
   description = "Bucket ARN"
 }
 
+output "bucket_region" {
+  value       = var.enabled ? join("", aws_s3_bucket.default.*.region) : ""
+  description = "Bucket region"
+}
+
 output "enabled" {
   value       = var.enabled
   description = "Is module enabled"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws   = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    aws   = ">= 2.0"
+    local = ">= 1.2"
+    null  = ">= 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws   = ">= 2.0"
+    aws   = ">= 3.0"
     local = ">= 1.2"
     null  = ">= 2.0"
   }


### PR DESCRIPTION
## what
set minimum versions for providers without pinning to a specific major version

## why
the current method makes it very difficult to maintain or upgrade consistent provider versions within a project
closes #46 

## references
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions
https://github.com/cloudposse/terraform-aws-iam-system-user/pull/33
https://github.com/cloudposse/terraform-aws-iam-s3-user/pull/19

