### PR TITLE
Fix version clash with other cloudposse repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 3.0 |
+| aws | >= 2.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
 
@@ -153,7 +153,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 3.0 |
+| aws | >= 2.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
 
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws   = ">= 3.0"
+    aws   = ">= 2.0"
     local = ">= 1.2"
     null  = ">= 2.0"
   }


### PR DESCRIPTION
I was using some of your other aws terraform projects and because they want version `~> 2.0` mostly. And this one wants >3.0 then it would not work:

```
Error: provider.aws: no suitable version installed
  version requirements: ">= 2.0,>= 2.0,>= 2.0,>= 2.0,>= 3.0,>= 3.0,~> 2.0,~> 2.0,~> 2.0,~> 2.0,~> 2.0,~> 2.0,~> 2.0"
  versions installed: "2.70.0"

```

So I've relaxed the requirement in this repo to resolve this.