### PR TITLE
Adds support for access logging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,14 @@ resource "aws_s3_bucket" "default" {
     }
   }
 
+  dynamic "logging" {
+    for_each = var.access_log_bucket_name != "" ? [1] : []
+    content {
+      target_bucket = var.access_log_bucket_name
+      target_prefix = "logs/${module.this.id}/"
+    }
+  }
+
   # https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
   # https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#enable-default-server-side-encryption
   server_side_encryption_configuration {

--- a/variables.tf
+++ b/variables.tf
@@ -166,3 +166,9 @@ variable "restrict_public_buckets" {
   default     = true
   description = "Set to `false` to disable the restricting of making the bucket public"
 }
+
+variable "access_log_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Name of the S3 bucket where s3 access logs will be sent"
+}


### PR DESCRIPTION
## what
* Adds support for S3 server access logging.

## why
* Record requests that are made for an S3 bucket.
* All our team's S3 buckets must have S3 server access logging enabled for compliance. Decided to use this module and extend it rather than reinvent the wheel. Figured I'd contribute it back.