### PR TITLE
Cross-account replication fix

### DIFF
--- a/replication.tf
+++ b/replication.tf
@@ -52,7 +52,8 @@ data "aws_iam_policy_document" "replication" {
       "s3:ReplicateObject",
       "s3:ReplicateDelete",
       "s3:ReplicateTags",
-      "s3:GetObjectVersionTagging"
+      "s3:GetObjectVersionTagging",
+      "s3:ObjectOwnerOverrideToBucketOwner"
     ]
 
     resources = ["${var.s3_replica_bucket_arn}/*"]


### PR DESCRIPTION
## what
* Add missing replication policy permissions

## why
* Without this permission cross-account replication is not possible

## references
* https://github.com/cloudposse/terraform-aws-s3-bucket/issues/68
* `closes #68`

