### PR TITLE
Removing policy attribute for S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-s3-bucket [![GitHub Action Tests](https://github.com/cloudposse/terraform-aws-s3-bucket/workflows/test/badge.svg?branch=master)](https://github.com/cloudposse/terraform-aws-s3-bucket/actions) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-s3-bucket.svg)](https://github.com/cloudposse/terraform-aws-s3-bucket/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -37,7 +38,6 @@ We do not recommend creating IAM users this way for any other purpose.
 It blocks public access to the bucket by default.
 https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -62,7 +62,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,6 @@ resource "aws_s3_bucket" "default" {
   bucket        = local.bucket_name
   acl           = try(length(var.grants), 0) == 0 ? var.acl : null
   force_destroy = var.force_destroy
-  policy        = var.policy
   tags          = module.this.tags
 
   versioning {

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ resource "aws_s3_bucket" "default" {
   #bridgecrew:skip=BC_AWS_S3_13:Skipping `Enable S3 Bucket Logging` because we do not have good defaults
   #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
   #bridgecrew:skip=BC_AWS_S3_16:Skipping `Ensure S3 bucket versioning is enabled` because dynamic blocks are not supported by checkov
+  #bridgecrew:skip=BC_AWS_S3_14:Skipping `Ensure all data stored in the S3 bucket is securely encrypted at rest` because variables are not understood
   count         = module.this.enabled ? 1 : 0
   bucket        = local.bucket_name
   acl           = try(length(var.grants), 0) == 0 ? var.acl : null


### PR DESCRIPTION
## what
* Fixing a bug where the bucket policy would flip-flop on Terraform apply if `var.policy` and any of `var.allow_ssl_requests_only`, `var.allow_encrypted_uploads_only` were set

## why
* The `aws_s3_bucket.policy` attribute was competing with the `aws_s3_bucket_policy` resource 

