### PR TITLE
Ability to specify website hosting configuration

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -46,7 +46,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,9 @@ name: auto-release
 on:
   push:
     branches:
+      - main
       - master
+      - production
 
 jobs:
   publish:
@@ -14,7 +16,7 @@ jobs:
         id: get-merged-pull-request
         with:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
         with:

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Available targets:
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_user_enabled"></a> [user\_enabled](#input\_user\_enabled) | Set to `true` to create an IAM user with permission to access the bucket | `bool` | `false` | no |
 | <a name="input_versioning_enabled"></a> [versioning\_enabled](#input\_versioning\_enabled) | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket | `bool` | `true` | no |
+| <a name="input_website_inputs"></a> [website\_inputs](#input\_website\_inputs) | Specifies the static website hosting configuration object. | <pre>list(object({<br>    index_document           = string<br>    error_document           = string<br>    redirect_all_requests_to = string<br>    routing_rules            = string<br>  }))</pre> | `null` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,6 +78,7 @@
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_user_enabled"></a> [user\_enabled](#input\_user\_enabled) | Set to `true` to create an IAM user with permission to access the bucket | `bool` | `false` | no |
 | <a name="input_versioning_enabled"></a> [versioning\_enabled](#input\_versioning\_enabled) | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket | `bool` | `true` | no |
+| <a name="input_website_inputs"></a> [website\_inputs](#input\_website\_inputs) | Specifies the static website hosting configuration object. | <pre>list(object({<br>    index_document           = string<br>    error_document           = string<br>    redirect_all_requests_to = string<br>    routing_rules            = string<br>  }))</pre> | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,16 @@ resource "aws_s3_bucket" "default" {
     }
   }
 
+  dynamic "website" {
+    for_each = var.website_inputs == null ? [] : var.website_inputs
+    content {
+      index_document           = website.value.index_document
+      error_document           = website.value.error_document
+      redirect_all_requests_to = website.value.redirect_all_requests_to
+      routing_rules            = website.value.routing_rules
+    }
+  }
+
   dynamic "cors_rule" {
     for_each = var.cors_rule_inputs == null ? [] : var.cors_rule_inputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,16 @@ variable "object_lock_configuration" {
   default     = null
   description = "A configuration for S3 object locking. With S3 Object Lock, you can store objects using a `write once, read many` (WORM) model. Object Lock can help prevent objects from being deleted or overwritten for a fixed amount of time or indefinitely."
 }
+
+variable "website_inputs" {
+
+  type = list(object({
+    index_document           = string
+    error_document           = string
+    redirect_all_requests_to = string
+    routing_rules            = string
+  }))
+  default = null
+
+  description = "Specifies the static website hosting configuration object."
+}


### PR DESCRIPTION
## what
* We already use this module for S3 and want to be able to use it to deploy S3 buckets with static website hosting configs
* The change in this PR adds that support

## why
* Would like to be able to use [cloudposse/terraform-aws-s3-bucket](https://github.com/cloudposse/terraform-aws-s3-bucket) (this module) to deploy buckets that support static website hosting and have very custom-tailored S3 bucket policy.
* Tried using [cloudposse/terraform-aws-s3-website](https://github.com/cloudposse/terraform-aws-s3-website) for the same need and hit the roadblock of it not supporting custom bucket policies.
* Our TF modules (in our org) are pinned down to use `cloudposse/terraform-aws-s3-bucket` for most S3 bucket needs, so we didn't have interest in using and modifying `cloudposse/terraform-aws-s3-website` module to support bucket custom bucket policies that are different then the "opinionated" ones that come with `cloudposse/terraform-aws-s3-website`.

## usage

Downstream TF modules using this feature then can specify website configuration as in the example below.

 * **file:** `profiles/s3_hosting_bucket/main.tf` 
    ```terraform
     module "s3_bucket" {
          source = "git::https://github.com/SkywardIO/terraform-aws-s3-bucket.git//?ref=feature/website-hosting-config"
          
          ## Switch to CP release version if PR gets accepted
          # source  = "cloudposse/s3-bucket/aws"
          # version = "0.38.0"
        
          #...
          # other config of the module
          #...
        
          
          # website hosting - switchboard specific
          website_inputs = var.website_inputs
     }
    ```
 * **file:** `profiles/s3_hosting_bucket/variables.tf` 
    ```terraform
    # ...
    # other variables
    # ...
    variable "website_inputs" {

        type = list(object({
          index_document           = string
          error_document           = string
          redirect_all_requests_to = string
          routing_rules            = string # if you need to render valid JSON for this, use var.routing_rules and export such map construct to JSON
        }))
        default = null
      
        description = "Specifies the static website hosting configuration object."
    }
    ```
 * **file:** `profiles/website/main.tf`
    ```terraform
    module "website" {
      source     = "../../profiles/s3_hosting_bucket"
      context    = module.this.context
      region     = var.region
      name       = module.this.name
      
      #...
      # other config of the module
      #...
      
      # determines static website hosting of the bucket - we are not interested in any kind of redirects by S3
      website_inputs = [
        {
          index_document           = "index.html"
          error_document           = "error.html"
          redirect_all_requests_to = null
          routing_rules            = var.routing_rules == null ? "" : jsonencode(var.routing_rules)
        }
      ]
      # next 4 variables determine "aws_s3_bucket_public_access_block" configuration
      block_public_acls       = var.block_public_acls
      block_public_policy     = var.block_public_policy
      ignore_public_acls      = var.ignore_public_acls
      restrict_public_buckets = var.restrict_public_buckets
      
    }
    ```

* **file:** `profiles/website/variables.tf`
   ```terraform
   # ...
   # other variables
   # ...
   variable "routing_rules" {
      type = list(object({
        RoutingRuleCondition = object({
          KeyPrefixEquals             = string
          HttpErrorCodeReturnedEquals = string
        })
        RedirectRule = object({
          HostName             = string
          HttpRedirectCode     = string
          Protocol             = string
          ReplaceKeyPrefixWith = string
          ReplaceKeyWith       = string
        })
      }))
      default = null
    
      description = "Specifies the helper generator for routing_rules key of website_inputs var - to obtain JSON easily."
   }
   ```
          

## references
* Can open an issue in this repo if there is need to further elaborate this.


