### PR TITLE
Feat: Enable Replication Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.68.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.68.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.7 |
 
 ## Modules

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.68.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.68.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.7 |
 
 ## Modules

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,7 +15,7 @@ module "s3_bucket" {
   allowed_bucket_actions        = var.allowed_bucket_actions
   bucket_name                   = var.bucket_name
   object_lock_configuration     = var.object_lock_configuration
-  s3_replication_enabled        = local.replication_enabled
+  s3_replication_enabled        = local.s3_replication_enabled
   s3_replica_bucket_arn         = join("", module.s3_bucket_replication_target.*.bucket_arn)
   s3_replication_rules          = local.s3_replication_rules
   privileged_principal_actions  = var.privileged_principal_actions

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -14,12 +14,12 @@ output "bucket_arn" {
 }
 
 output "replication_bucket_id" {
-  value       = local.replication_enabled ? join("", module.s3_bucket_replication_target.*.bucket_id) : null
+  value       = local.s3_replication_enabled ? join("", module.s3_bucket_replication_target.*.bucket_id) : null
   description = "Replication bucket ID"
 }
 
 output "replication_bucket_arn" {
-  value       = local.replication_enabled ? join("", module.s3_bucket_replication_target.*.bucket_arn) : null
+  value       = local.s3_replication_enabled ? join("", module.s3_bucket_replication_target.*.bucket_arn) : null
   description = "Replication bucket bucket ARN"
 }
 

--- a/examples/complete/replication.us-east-2.tfvars
+++ b/examples/complete/replication.us-east-2.tfvars
@@ -28,11 +28,4 @@ allowed_bucket_actions = [
   "s3:AbortMultipartUpload",
 ]
 
-# Rules will be augmented with an additional bucket rule, so prefix cannot be "/"
-s3_replication_rules = [
-  {
-    id     = "replication-test"
-    status = "Enabled"
-    prefix = "/main"
-  }
-]
+s3_replication_enabled = true

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -63,9 +63,10 @@ variable "lifecycle_rules" {
   description = "A list of lifecycle rules."
 }
 
-variable "s3_replication_rules" {
-  default     = []
-  description = "S3 replication rules"
+variable "s3_replication_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable or disable S3 replication."
 }
 
 variable "policy" {

--- a/main.tf
+++ b/main.tf
@@ -195,10 +195,12 @@ resource "aws_s3_bucket" "default" {
               }
             }
 
+            # This block is required when replication metrics are enabled.
             dynamic "replication_time" {
               for_each = try(rules.value.destination.metrics.status, "") == "Enabled" ? [1] : []
 
               content {
+                # ReplicationTime:Time:Minutes can only have 15 as a valid value.
                 minutes = 15
               }
             }

--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ resource "aws_s3_bucket" "default" {
               for_each = try(rules.value.destination.metrics.status, "") == "Enabled" ? [1] : []
 
               content {
-                status  = "Enabled"
+                status = "Enabled"
               }
             }
 

--- a/main.tf
+++ b/main.tf
@@ -192,6 +192,8 @@ resource "aws_s3_bucket" "default" {
 
               content {
                 status = "Enabled"
+                # Minutes can only have 15 as a valid value.
+                minutes = 15
               }
             }
 
@@ -200,7 +202,8 @@ resource "aws_s3_bucket" "default" {
               for_each = try(rules.value.destination.metrics.status, "") == "Enabled" ? [1] : []
 
               content {
-                # ReplicationTime:Time:Minutes can only have 15 as a valid value.
+                status = "Enabled"
+                # Minutes can only have 15 as a valid value.
                 minutes = 15
               }
             }

--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,23 @@ resource "aws_s3_bucket" "default" {
             replica_kms_key_id = try(rules.value.destination.replica_kms_key_id, null)
             account_id         = try(rules.value.destination.account_id, null)
 
+            # https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-walkthrough-5.html
+            dynamic "metrics" {
+              for_each = try(rules.value.destination.metrics.status, "") == "Enabled" ? [1] : []
+
+              content {
+                status  = "Enabled"
+              }
+            }
+
+            dynamic "replication_time" {
+              for_each = try(rules.value.destination.metrics.status, "") == "Enabled" ? [1] : []
+
+              content {
+                minutes = 15
+              }
+            }
+
             dynamic "access_control_translation" {
               for_each = try(rules.value.destination.access_control_translation.owner, null) == null ? [] : [rules.value.destination.access_control_translation.owner]
 

--- a/variables.tf
+++ b/variables.tf
@@ -197,7 +197,7 @@ variable "s3_replication_rules" {
   #     })
   #     account_id                 = string
   #     metrics                    = object({
-  #       status = Enabled
+  #       status = string
   #     })
   #   })
   #   source_selection_criteria = object({

--- a/variables.tf
+++ b/variables.tf
@@ -196,6 +196,9 @@ variable "s3_replication_rules" {
   #       owner = string
   #     })
   #     account_id                 = string
+  #     metrics                    = object({
+  #       status = Enabled
+  #     })
   #   })
   #   source_selection_criteria = object({
   #     sse_kms_encrypted_objects = object({

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.68.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## what
* Enable replication metrics by default
* Allow override via variables

AWS provider requirements update due to: https://github.com/hashicorp/terraform-provider-aws/pull/21901

## why
* To be able to track replication status

## references
https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-metrics.html

