### PR TITLE
Dynamic block for versioning added

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,11 +25,11 @@ resource "aws_s3_bucket" "default" {
   acceleration_status = var.transfer_acceleration_enabled ? "Enabled" : null
 
   dynamic "versioning" {
-      for_each = var.versioning_enabled ? [true] : []
-      content {
-        enabled = true
-      }
+    for_each = var.versioning_enabled ? [true] : []
+    content {
+      enabled = true
     }
+  }
 
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rules

--- a/main.tf
+++ b/main.tf
@@ -24,9 +24,12 @@ resource "aws_s3_bucket" "default" {
   tags                = module.this.tags
   acceleration_status = var.transfer_acceleration_enabled ? "Enabled" : null
 
-  versioning {
-    enabled = var.versioning_enabled
-  }
+  dynamic "versioning" {
+      for_each = var.versioning_enabled ? [true] : []
+      content {
+        enabled = true
+      }
+    }
 
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rules


### PR DESCRIPTION
## what
Enabling `versioning` on a bucket is a permanent action that cannot be disabled. For this reason, when `versioning` attribute is added to the s3 resource, the bucket is prepared to be `versioned` and put in suspended mode. The only way to avoid this and keep the versioning disabled is to not add the `versioning` attribute at all.

We were discussing this in [this bug](https://github.com/cloudposse/terraform-aws-s3-bucket/issues/76) and @aknysh posted a snipped which is removing the attribute, making it possible to set `versioning` off instead of enabled but suspended.

I'm just adding that snippet, [there's another PR](https://github.com/cloudposse/terraform-aws-s3-bucket/pull/77) which is apparently changing more than just the versioning and it seems abandoned (opened in February 2021, had no updates from August).

Note: there's a comment into this module's main:
```
#bridgecrew:skip=BC_AWS_S3_16:Skipping `Ensure S3 bucket versioning is enabled` because dynamic blocks are not supported by checkov
```

But I see that some basic handling for dynamic blocks has been added in checkov
[bridgecrewio/checkov#836](https://github.com/bridgecrewio/checkov/pull/836)

So if you're using checkov it would be interesting to remove the comment and see if it works now

## why
- In a very quick deployment, where versioning is less important than speed, having a delay before an object can be written could be an issue ([See the note here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html))
- If the buckets are created by terraform and deleted by a script, the versioned bucket's deletion is much more complex than a non-versioned one.
- User's preference
