### PR TITLE
feat: add delete_marker_replication_status in replication rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,7 @@ resource "aws_s3_bucket" "default" {
           # `prefix` conflicts with `filter`, and for multiple destinations, a filter block
           # is required even if it empty, so we always implement `prefix` as a filter.
           # OBSOLETE: prefix   = try(rules.value.prefix, null)
-          status                           = try(rules.value.status, null)
+          status = try(rules.value.status, null)
           # The `Delete marker replication` was disabled by default since empty filter created in Line 210, this needed to be "Enabled" to turn it on
           delete_marker_replication_status = try(rules.value.delete_marker_replication_status, null)
 

--- a/main.tf
+++ b/main.tf
@@ -172,7 +172,9 @@ resource "aws_s3_bucket" "default" {
           # `prefix` conflicts with `filter`, and for multiple destinations, a filter block
           # is required even if it empty, so we always implement `prefix` as a filter.
           # OBSOLETE: prefix   = try(rules.value.prefix, null)
-          status = try(rules.value.status, null)
+          status                           = try(rules.value.status, null)
+          # The `Delete marker replication` was disabled by default since empty filter created in Line 210, this needed to be "Enabled" to turn it on
+          delete_marker_replication_status = try(rules.value.delete_marker_replication_status, null)
 
           destination {
             # Prefer newer system of specifying bucket in rule, but maintain backward compatibility with

--- a/variables.tf
+++ b/variables.tf
@@ -190,6 +190,7 @@ variable "s3_replication_rules" {
   #   priority    = number
   #   prefix      = string
   #   status      = string
+  #   delete_marker_replication_status = string
   #   # destination_bucket is specified here rather than inside the destination object
   #   # to make it easier to work with the Terraform type system and create a list of consistent type.
   #   destination_bucket = string # destination bucket ARN, overrides s3_replica_bucket_arn


### PR DESCRIPTION
## what
* There are no control ability for enable `Delete marker replication` in this module

## why
* The reason of this was because empty `filter` would always be generated in this [line](https://github.com/cloudposse/terraform-aws-s3-bucket/blob/816e61ab796a159e9f949350a1645576761dad8a/main.tf#L208)
* And this will disable the `Delete marker replication` option in replication rule

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#delete_marker_replication_status
