### PR TITLE
dynamically create website inputs with the new provider and its colli…

### DIFF
--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,5 +1,7 @@
 name: "auto-readme"
 on:
+  workflow_dispatch:
+
   schedule:
   # Example of job definition:
   # .---------------- minute (0 - 59)
@@ -15,21 +17,35 @@ on:
 
 jobs:
   update:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme
       shell: bash
       id: update
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
       run: |
         make init
         make readme/build
         # Ignore changes if they are only whitespace
-        git diff --ignore-all-space --ignore-blank-lines --quiet README.md && { git restore README.md; echo Ignoring whitespace-only changes in README; }
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
 
     - name: Create Pull Request
       # This action will not create or change a pull request if there are no changes to make.
@@ -47,7 +63,7 @@ jobs:
           To have most recent changes of README.md and doc from origin templates
 
         branch: auto-update/readme
-        base: main
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
         delete-branch: true
         labels: |
           auto-update

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Available targets:
 | <a name="input_transfer_acceleration_enabled"></a> [transfer\_acceleration\_enabled](#input\_transfer\_acceleration\_enabled) | Set this to true to enable S3 Transfer Acceleration for the bucket. | `bool` | `false` | no |
 | <a name="input_user_enabled"></a> [user\_enabled](#input\_user\_enabled) | Set to `true` to create an IAM user with permission to access the bucket | `bool` | `false` | no |
 | <a name="input_versioning_enabled"></a> [versioning\_enabled](#input\_versioning\_enabled) | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket | `bool` | `true` | no |
-| <a name="input_website_inputs"></a> [website\_inputs](#input\_website\_inputs) | Specifies the static website hosting configuration object. | <pre>list(object({<br>    index_document           = string<br>    error_document           = string<br>    redirect_all_requests_to = string<br>    routing_rules            = string<br>  }))</pre> | `null` | no |
+| <a name="input_website_inputs"></a> [website\_inputs](#input\_website\_inputs) | Specifies the static website hosting configuration object. | `map(any)` | `null` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -105,7 +105,7 @@
 | <a name="input_transfer_acceleration_enabled"></a> [transfer\_acceleration\_enabled](#input\_transfer\_acceleration\_enabled) | Set this to true to enable S3 Transfer Acceleration for the bucket. | `bool` | `false` | no |
 | <a name="input_user_enabled"></a> [user\_enabled](#input\_user\_enabled) | Set to `true` to create an IAM user with permission to access the bucket | `bool` | `false` | no |
 | <a name="input_versioning_enabled"></a> [versioning\_enabled](#input\_versioning\_enabled) | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket | `bool` | `true` | no |
-| <a name="input_website_inputs"></a> [website\_inputs](#input\_website\_inputs) | Specifies the static website hosting configuration object. | <pre>list(object({<br>    index_document           = string<br>    error_document           = string<br>    redirect_all_requests_to = string<br>    routing_rules            = string<br>  }))</pre> | `null` | no |
+| <a name="input_website_inputs"></a> [website\_inputs](#input\_website\_inputs) | Specifies the static website hosting configuration object. | `map(any)` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ resource "aws_s3_bucket_website_configuration" "default" {
   }
 
   dynamic "redirect_all_requests_to" {
-    for_each  = length(each.value.redirect_all_requests_to) > 0 ? each.value.redirect_all_requests_to : []
+    for_each = length(each.value.redirect_all_requests_to) > 0 ? each.value.redirect_all_requests_to : []
 
     content {
       host_name = redirect_all_requests_to.value.hostname

--- a/variables.tf
+++ b/variables.tf
@@ -276,12 +276,7 @@ variable "object_lock_configuration" {
 
 variable "website_inputs" {
 
-  type = list(object({
-    index_document           = string
-    error_document           = string
-    redirect_all_requests_to = string
-    routing_rules            = string
-  }))
+  type = map
   default = null
 
   description = "Specifies the static website hosting configuration object."

--- a/variables.tf
+++ b/variables.tf
@@ -276,7 +276,7 @@ variable "object_lock_configuration" {
 
 variable "website_inputs" {
 
-  type = map
+  type    = map(any)
   default = null
 
   description = "Specifies the static website hosting configuration object."


### PR DESCRIPTION
…ding options

## what
* this fixes type issues and changes with the new AWS provider for website inputs

## why
* Right now we can not upgrade because this dynamic block is broken
* https://registry.terraform.io/providers/hashicorp/aws/4.1.0/docs/resources/s3_bucket_website_configuration#argument-reference
* some options are mutually exclusive, so handle this.

## references
* Closes https://github.com/cloudposse/terraform-aws-s3-bucket/issues/141

