### PR TITLE
Removed deprecated argument. object_lock_enabled is enabled for this …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_s3_bucket" "default" {
   count         = local.enabled ? 1 : 0
   bucket        = local.bucket_name
   force_destroy = var.force_destroy
-
+  
   tags = module.this.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -38,14 +38,6 @@ resource "aws_s3_bucket" "default" {
   bucket        = local.bucket_name
   force_destroy = var.force_destroy
 
-  dynamic "object_lock_configuration" {
-    for_each = var.object_lock_configuration != null ? [1] : []
-
-    content {
-      object_lock_enabled = "Enabled"
-    }
-  }
-
   tags = module.this.tags
 }
 


### PR DESCRIPTION
…bucket in resource aws_s3_bucket_object_lock_configuration.default

## what
* Removed deprecated argument object_lock_enabled from aws_s3_bucket.default. object_lock_enabled is enabled for this bucket in resource aws_s3_bucket_object_lock_configuration.default

## why
* object_lock_enabled has been deprecated in the bucket resource.
* 
## references
* Terraform AWS S3 Bucket resource - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket

