### PR TITLE
Update Terraform cloudposse/iam-s3-user/aws module initialization - a…

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_user"></a> [s3\_user](#module\_s3\_user) | cloudposse/iam-s3-user/aws | 0.15.10 |
+| <a name="module_s3_user"></a> [s3\_user](#module\_s3\_user) | cloudposse/iam-s3-user/aws | 0.15.11 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -544,7 +544,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-bucket&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-bucket&utm_content=website
@@ -575,3 +575,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-s3-bucket
   [share_email]: mailto:?subject=terraform-aws-s3-bucket&body=https://github.com/cloudposse/terraform-aws-s3-bucket
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-s3-bucket?pixel&cs=github&cm=readme&an=terraform-aws-s3-bucket
+<!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ locals {
 }
 ```
 
-Using [grants](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) to enable access
+Using [grants](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) to enable access 
 to another account and for logging, and incorporating the above lifecycle configuration.
 
 ```hcl
@@ -218,13 +218,13 @@ module "s3_bucket" {
     "arn:aws:iam::123456789012:role/principal2" = [""]
   }]
   privileged_principal_actions = [
-    "s3:PutObject",
-    "s3:PutObjectAcl",
-    "s3:GetObject",
-    "s3:DeleteObject",
-    "s3:ListBucket",
-    "s3:ListBucketMultipartUploads",
-    "s3:GetBucketLocation",
+    "s3:PutObject", 
+    "s3:PutObjectAcl", 
+    "s3:GetObject", 
+    "s3:DeleteObject", 
+    "s3:ListBucket", 
+    "s3:ListBucketMultipartUploads", 
+    "s3:GetBucketLocation", 
     "s3:AbortMultipartUpload"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ locals {
 }
 ```
 
-Using [grants](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) to enable access 
+Using [grants](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) to enable access
 to another account and for logging, and incorporating the above lifecycle configuration.
 
 ```hcl
@@ -218,13 +218,13 @@ module "s3_bucket" {
     "arn:aws:iam::123456789012:role/principal2" = [""]
   }]
   privileged_principal_actions = [
-    "s3:PutObject", 
-    "s3:PutObjectAcl", 
-    "s3:GetObject", 
-    "s3:DeleteObject", 
-    "s3:ListBucket", 
-    "s3:ListBucketMultipartUploads", 
-    "s3:GetBucketLocation", 
+    "s3:PutObject",
+    "s3:PutObjectAcl",
+    "s3:GetObject",
+    "s3:DeleteObject",
+    "s3:ListBucket",
+    "s3:ListBucketMultipartUploads",
+    "s3:GetBucketLocation",
     "s3:AbortMultipartUpload"
   ]
 }
@@ -322,6 +322,7 @@ Available targets:
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | When `true`, permits a non-empty S3 bucket to be deleted by first deleting all objects in the bucket.<br>THESE OBJECTS ARE NOT RECOVERABLE even if they were versioned and stored in Glacier. | `bool` | `false` | no |
 | <a name="input_grants"></a> [grants](#input\_grants) | A list of policy grants for the bucket, taking a list of permissions.<br>Conflicts with `acl`. Set `acl` to `null` to use this. | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |
+| <a name="input_iam_access_key_max_age"></a> [iam\_access\_key\_max\_age](#input\_iam\_access\_key\_max\_age) | Maximum age of IAM access key (seconds). Defaults to 30 days. Set to 0 to disable expiration. | `number` | `2592000` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Set to `false` to disable the ignoring of public access lists on the bucket | `bool` | `true` | no |
 | <a name="input_kms_master_key_arn"></a> [kms\_master\_key\_arn](#input\_kms\_master\_key\_arn) | The AWS KMS master key ARN used for the `SSE-KMS` encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default aws/s3 AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms` | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_user"></a> [s3\_user](#module\_s3\_user) | cloudposse/iam-s3-user/aws | 0.15.10 |
+| <a name="module_s3_user"></a> [s3\_user](#module\_s3\_user) | cloudposse/iam-s3-user/aws | 0.15.11 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -72,6 +72,7 @@
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | When `true`, permits a non-empty S3 bucket to be deleted by first deleting all objects in the bucket.<br>THESE OBJECTS ARE NOT RECOVERABLE even if they were versioned and stored in Glacier. | `bool` | `false` | no |
 | <a name="input_grants"></a> [grants](#input\_grants) | A list of policy grants for the bucket, taking a list of permissions.<br>Conflicts with `acl`. Set `acl` to `null` to use this. | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |
+| <a name="input_iam_access_key_max_age"></a> [iam\_access\_key\_max\_age](#input\_iam\_access\_key\_max\_age) | Maximum age of IAM access key (seconds). Defaults to 30 days. Set to 0 to disable expiration. | `number` | `2592000` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Set to `false` to disable the ignoring of public access lists on the bucket | `bool` | `true` | no |
 | <a name="input_kms_master_key_arn"></a> [kms\_master\_key\_arn](#input\_kms\_master\_key\_arn) | The AWS KMS master key ARN used for the `SSE-KMS` encryption. This can only be used when you set the value of `sse_algorithm` as `aws:kms`. The default aws/s3 AWS KMS master key is used if this element is absent while the `sse_algorithm` is `aws:kms` | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -301,11 +301,12 @@ resource "aws_s3_bucket_object_lock_configuration" "default" {
 
 module "s3_user" {
   source  = "cloudposse/iam-s3-user/aws"
-  version = "0.15.10"
+  version = "0.15.11"
 
-  enabled      = local.enabled && var.user_enabled
-  s3_actions   = var.allowed_bucket_actions
-  s3_resources = ["${join("", aws_s3_bucket.default.*.arn)}/*", join("", aws_s3_bucket.default.*.arn)]
+  enabled                = local.enabled && var.user_enabled
+  s3_actions             = var.allowed_bucket_actions
+  s3_resources           = ["${join("", aws_s3_bucket.default.*.arn)}/*", join("", aws_s3_bucket.default.*.arn)]
+  iam_access_key_max_age = var.iam_access_key_max_age
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -328,3 +328,14 @@ variable "bucket_key_enabled" {
   For more information, see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html
   EOT
 }
+
+variable "iam_access_key_max_age" {
+  type        = number
+  description = "Maximum age of IAM access key (seconds). Defaults to 30 days. Set to 0 to disable expiration."
+  default     = 2592000
+
+  validation {
+    condition     = var.iam_access_key_max_age >= 0
+    error_message = "The iam_access_key_max_age must be 0 (disabled) or greater."
+  }
+}


### PR DESCRIPTION
…dded iam_access_key_max_age parameter

## what
* iam_access_key_max_age was added to the variables.tf file as a copy from cloudposse/iam-system-user/aws module
* iam_access_key_max_age is handed over as a parameter in cloudposse/iam-s3-user/aws module instatiation
* the next cloudposse/iam-s3-user/aws version is just guessed by an open PR, created in the same context

## why
* iam_access_key_max_age defaults to 30 days now on cloudposse/iam-system-user/aws
* when this module is updated, this leads to a recreation of the s3 user with an expired Access Key

## references
* [PR on cloudposse/terraform-aws-iam-s3-user](https://github.com/cloudposse/terraform-aws-iam-s3-user/pull/47)

