### PR TITLE
Update `sse_kms_encrypted_objects` for `s3_bucket_replication_configuration`

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/main.tf
+++ b/main.tf
@@ -263,11 +263,10 @@ resource "aws_s3_bucket_replication_configuration" "default" {
       }
 
       dynamic "source_selection_criteria" {
-        for_each = try(rule.value.source_selection_criteria.sse_kms_encrypted_objects.enabled, null) == null ? [] : [rule.value.source_selection_criteria.sse_kms_encrypted_objects.enabled]
-
+        for_each = try(rule.value.source_selection_criteria.sse_kms_encrypted_objects.enabled, "") == "Enabled" ? [1] : []
         content {
           sse_kms_encrypted_objects {
-            status = source_selection_criteria.value
+            status = "Enabled"
           }
         }
       }

--- a/main.tf
+++ b/main.tf
@@ -263,7 +263,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
       }
 
       dynamic "source_selection_criteria" {
-        for_each = try(rule.value.source_selection_criteria.sse_kms_encrypted_objects.enabled, "") == "Enabled" ? [1] : []
+        for_each = try(rule.value.source_selection_criteria.sse_kms_encrypted_objects.status, "") == "Enabled" ? [1] : []
         content {
           sse_kms_encrypted_objects {
             status = "Enabled"


### PR DESCRIPTION
Right now the replication option is broken for encrypted objects. This fixes the logic.  

[TF docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration#source_selection_criteria)

