### PR TITLE
fix: Use source_policy_documents var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -455,7 +455,7 @@ data "aws_iam_policy_document" "aggregated_policy" {
   count = local.enabled ? 1 : 0
 
   source_policy_documents   = data.aws_iam_policy_document.bucket_policy.*.json
-  override_policy_documents = local.source_policy_documents
+  override_policy_documents = var.source_policy_documents
 }
 
 resource "aws_s3_bucket_policy" "default" {


### PR DESCRIPTION
## what
* [The source_policy_documents variable](https://github.com/cloudposse/terraform-aws-s3-bucket/blob/master/main.tf#L458) is ignored since it's referencing an undefined local.source_policy_documents variable, using the value from the variable source_policy_documents instead.

## why
* Currently the values provided in the source_policy_documents variable aren't used in the bucket policy.

## references
* closes #165 

