### PR TITLE
Add support for permission boundaries on replication IAM role

### DIFF
--- a/replication.tf
+++ b/replication.tf
@@ -3,7 +3,7 @@ resource "aws_iam_role" "replication" {
 
   name                 = format("%s-replication", module.this.id)
   assume_role_policy   = data.aws_iam_policy_document.replication_sts[0].json
-  permissions_boundary = var.s3_replication_permission_boundry_arn
+  permissions_boundary = var.s3_replication_permission_boundary_arn
 }
 
 data "aws_iam_policy_document" "replication_sts" {

--- a/replication.tf
+++ b/replication.tf
@@ -1,8 +1,9 @@
 resource "aws_iam_role" "replication" {
   count = local.replication_enabled ? 1 : 0
 
-  name               = format("%s-replication", module.this.id)
-  assume_role_policy = data.aws_iam_policy_document.replication_sts[0].json
+  name                 = format("%s-replication", module.this.id)
+  assume_role_policy   = data.aws_iam_policy_document.replication_sts[0].json
+  permissions_boundary = var.s3_replication_permission_boundry_arn
 }
 
 data "aws_iam_policy_document" "replication_sts" {

--- a/variables.tf
+++ b/variables.tf
@@ -280,10 +280,10 @@ variable "s3_replication_source_roles" {
   description = "Cross-account IAM Role ARNs that will be allowed to perform S3 replication to this bucket (for replication within the same AWS account, it's not necessary to adjust the bucket policy)."
 }
 
-variable "s3_replication_permission_boundry_arn" {
+variable "s3_replication_permission_boundary_arn" {
   type        = string
   default     = null
-  description = "Permission boundry of the IAM replication role. Defaults to null."
+  description = "Permission boundary ARN of the IAM replication role. Defaults to null."
 }
 
 variable "bucket_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,12 @@ variable "s3_replication_source_roles" {
   description = "Cross-account IAM Role ARNs that will be allowed to perform S3 replication to this bucket (for replication within the same AWS account, it's not necessary to adjust the bucket policy)."
 }
 
+variable "s3_replication_permission_boundry_arn" {
+  type        = string
+  default     = null
+  description = "Permission boundry of the IAM replication role. Defaults to null."
+}
+
 variable "bucket_name" {
   type        = string
   default     = null


### PR DESCRIPTION
## what
* Adds support for assigning [permission boundaries](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) to the replication IAM role

## why
* Our AWS environment enforces permission boundaries on all IAM roles to follow AWS best practices with security.

## references
* [AWS IAM Access Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)

