### PR TITLE
Post April 2023 ACLs no longer allowed by default so wait for changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,7 @@ resource "aws_s3_bucket_acl" "default" {
       }
     }
   }
+  depends_on = [time_sleep.wait_for_aws_s3_ownership_change]
 }
 
 resource "aws_s3_bucket_replication_configuration" "default" {
@@ -493,6 +494,13 @@ resource "aws_s3_bucket_ownership_controls" "default" {
 resource "time_sleep" "wait_for_aws_s3_bucket_settings" {
   count            = local.enabled ? 1 : 0
   depends_on       = [aws_s3_bucket_public_access_block.default, aws_s3_bucket_policy.default]
+  create_duration  = "30s"
+  destroy_duration = "30s"
+}
+
+resource "time_sleep" "wait_for_aws_s3_ownership_change" {
+  count            = local.enabled ? 1 : 0
+  depends_on       = [aws_s3_bucket_ownership_controls.default]
   create_duration  = "30s"
   destroy_duration = "30s"
 }


### PR DESCRIPTION
## what
* Wait a little while after configuring bucket ownership controls on a new S3 bucket before configuring the bucket ACL

## why
* Post April 2023, ACLs are disabled by default for all new S3 buckets which can cause a race condition when trying to apply a canned ACL to a new S3 bucket - https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/
* If you try to use the resource`aws_s3_bucket_acl` too quickly after the resource `aws_s3_bucket_ownership_controls` then ACLs may still be disabled on your new S3 bucket and your `terraform apply` will fail. If you re-run your `apply` then it works just fine the second time around as the propagation of the change in bucket ownership has finished.

## references
* None

