### PR TITLE
bucket ACL depends_on on bucket ownership controls (fix for new aws defaults)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,10 @@ resource "aws_s3_bucket_acl" "default" {
       }
     }
   }
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.default
+  ]
 }
 
 resource "aws_s3_bucket_replication_configuration" "default" {


### PR DESCRIPTION


## what
* Now the aws_s3_bucket_acl resource will wait for the aws_s3_bucket_ownership_controls resource to be finished.

## why
* Because of the [recent AWS changes to default values on new S3 buckets](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/),  all new s3 buckets start out with the `ObjectOwnership` set to `BucketOwnerEnforced`.
* This means that when we try to create the `aws_s3_bucket_acl` resource on a brand new S3 bucket, we will always get `AccessControlListNotSupported: The bucket does not allow ACLs` 
* Waiting for the `aws_s3_bucket_ownership_controls` to exist guarantees that if the ACL is supposed to be created, it can be created because now the bucket will allow ACLs (For example, with the `BucketOwnerPreferred` or `ObjectWriter` ownership settings now applied)

## references
* closes https://github.com/cloudposse/terraform-aws-s3-bucket/issues/174
* https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
* https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html

