### PR TITLE
Add: ACL depends on ownership_controls

### DIFF
--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -37,7 +37,7 @@ jobs:
       if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -37,7 +37,7 @@ jobs:
       if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -19,7 +19,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       name: Privileged Checkout
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         # Check out the PR commit, not the merge commit
         # Use `ref` instead of `sha` to enable pushing back to `ref`
@@ -30,7 +30,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       shell: bash
       env:
-        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        GITHUB_TOKEN: "${{ secrets.REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch
@@ -75,7 +75,7 @@ jobs:
         contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
         && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: cloudposse/actions
         event-type: test-command
         client-payload: |-

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -52,7 +52,7 @@ jobs:
       # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         commit-message: Update README.md and docs
         title: Update README.md and docs
         body: |-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
@@ -23,4 +23,4 @@ jobs:
           prerelease: false
           config-name: auto-release.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Handle common commands"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
@@ -26,7 +26,7 @@ jobs:
       - name: "Run tests"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: test

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -20,7 +20,7 @@ jobs:
         checks: "syntax,owners,duppatterns"
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
-        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"

--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,12 @@ resource "aws_s3_bucket_acl" "default" {
       }
     }
   }
+  
+  # AWS changed default ObjectOwnership = Bucket Owner Preferred.
+  # To add ACL `aws_s3_bucket_ownership_controls` must be set to `ObjectWriter` (or) `BucketOwnerPreferred`
+  # Ref: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ 
+  depends_on = [aws_s3_bucket_ownership_controls.default]
+}
 }
 
 resource "aws_s3_bucket_replication_configuration" "default" {

--- a/main.tf
+++ b/main.tf
@@ -157,7 +157,7 @@ resource "aws_s3_bucket_cors_configuration" "default" {
 }
 
 resource "aws_s3_bucket_acl" "default" {
-  count  = local.enabled ? 1 : 0
+  count  = local.enabled && var.s3_object_ownership != "BucketOwnerEnforced" ? 1 : 0
   bucket = join("", aws_s3_bucket.default.*.id)
 
   # Conflicts with access_control_policy so this is enabled if no grants

--- a/main.tf
+++ b/main.tf
@@ -186,8 +186,8 @@ resource "aws_s3_bucket_acl" "default" {
     }
   }
   
-  # AWS changed default ObjectOwnership = Bucket Owner Preferred.
-  # To add ACL `aws_s3_bucket_ownership_controls` must be set to `ObjectWriter` (or) `BucketOwnerPreferred`
+  # Starting April 2023, AWS changed default ObjectOwnership = Bucket Owner Preferred, on bucket creation with API, CLI, SDK, CF as well.
+  # To add ACL `aws_s3_bucket_ownership_controls` must be set to `ObjectWriter` (or) `BucketOwnerPreferred` first
   # Ref: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ 
   depends_on = [aws_s3_bucket_ownership_controls.default]
 }

--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,6 @@ resource "aws_s3_bucket_acl" "default" {
   # Ref: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ 
   depends_on = [aws_s3_bucket_ownership_controls.default]
 }
-}
 
 resource "aws_s3_bucket_replication_configuration" "default" {
   count = local.replication_enabled ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,7 @@ resource "aws_s3_bucket_acl" "default" {
     }
   }
   
-  # Starting April 2023, AWS changed default ObjectOwnership = Bucket Owner Preferred, on bucket creation with API, CLI, SDK, CF as well.
+  # Starting April 2023, AWS changed default ObjectOwnership = Bucket Owner Preferred on bucket creation with API, CLI, SDK, CF as well
   # To add ACL `aws_s3_bucket_ownership_controls` must be set to `ObjectWriter` (or) `BucketOwnerPreferred` first
   # Ref: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ 
   depends_on = [aws_s3_bucket_ownership_controls.default]

--- a/variables.tf
+++ b/variables.tf
@@ -365,8 +365,8 @@ variable "transfer_acceleration_enabled" {
 
 variable "s3_object_ownership" {
   type        = string
-  default     = "ObjectWriter"
-  description = "Specifies the S3 object ownership control. Valid values are `ObjectWriter`, `BucketOwnerPreferred`, and 'BucketOwnerEnforced'."
+  default     = "BucketOwnerEnforced"
+  description = "Specifies the S3 object ownership control. Valid values are `ObjectWriter`, `BucketOwnerPreferred`, and 'BucketOwnerEnforced'. Default = BucketOwnerEnforced"
 }
 
 variable "bucket_key_enabled" {


### PR DESCRIPTION
## what
- aws_s3_bucket_ownership_controls is set first, followed by bucket ACL.

## why
- Starting April 2023, AWS has changed default ObjectOwnership = Bucket Owner Preferred.
So to add ACL `aws_s3_bucket_ownership_controls` must be set to `ObjectWriter` (or) `BucketOwnerPreferred` first.
In this PR, `aws_s3_bucket_acl` depends_on `aws_s3_bucket_ownership_controls` resource block.
aws_s3_bucket_ownership_controls default set to `BucketOwnerEnforced`

## references
- Ref: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

