### PR TITLE
Sets Bucket ACL after its ownership controls were set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,11 @@ resource "aws_s3_bucket_acl" "default" {
       }
     }
   }
+
+  depends_on = [
+    # ACL must be set after Ownership Controls were set
+    aws_s3_bucket_ownership_controls.default
+  ]
 }
 
 resource "aws_s3_bucket_replication_configuration" "default" {


### PR DESCRIPTION
## what
* makes ACL to be defined after the Ownership Control is set

## why
* AWS changed the default value for Ownership Controls to `BucketOwnerEnforced` and this conflicts with having an ACL set on the bucket

## references
* fixes issue from Cloudposse's Cloudfront CDN module https://github.com/cloudposse/terraform-aws-cloudfront-cdn/issues/96

