### PR TITLE
Remove reference to TF_DATA_DIR retained by mistake in #40

### DIFF
--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -26,4 +26,4 @@ docker/test:
 .PHONY : clean
 ## Clean up files
 clean:
-	rm -rf $(TF_DATA_DIR) ../../examples/complete/*.tfstate*
+	rm -rf ../../examples/complete/*.tfstate*


### PR DESCRIPTION
## what

- Remove reference to `TF_DATA_DIR` in `test/src/Makefile` retained by mistake in #40

## why

- Added by mistake, has potential for abuse or innocent misuse to cause big problems

