### PR TITLE
Fix `source_policy_documents` combined with `var.policy` being ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 Using a [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 

--- a/main.tf
+++ b/main.tf
@@ -459,7 +459,7 @@ data "aws_iam_policy_document" "aggregated_policy" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count      = local.enabled && (var.allow_ssl_requests_only || var.allow_encrypted_uploads_only || length(var.s3_replication_source_roles) > 0 || length(var.privileged_principal_arns) > 0 || length(var.source_policy_documents) > 0) ? 1 : 0
+  count      = local.enabled && (var.allow_ssl_requests_only || var.allow_encrypted_uploads_only || length(var.s3_replication_source_roles) > 0 || length(var.privileged_principal_arns) > 0 || length(local.source_policy_documents) > 0) ? 1 : 0
   bucket     = join("", aws_s3_bucket.default[*].id)
   policy     = join("", data.aws_iam_policy_document.aggregated_policy[*].json)
   depends_on = [aws_s3_bucket_public_access_block.default]


### PR DESCRIPTION
## what

- Changed `var.source_policy_documents` to `local.source_policy_documents` so `var.policy` usage was still supported

## why

- The ternary check uses `var,source_policy_documents` so `var.policy` being combined with `var.source_policy_documents` into `local.source_policy_documents` does not provide `true` for the ternary to execute

## references

- https://github.com/cloudposse/terraform-aws-config-storage/pull/39