### PR TITLE
fix: use for_each instead of count in aws_s3_bucket_logging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,11 @@ resource "aws_s3_bucket_versioning" "default" {
   }
 }
 
+moved {
+  from = aws_s3_bucket_logging.default[0]
+  to   = aws_s3_bucket_logging.default["enabled"]
+}
+
 resource "aws_s3_bucket_logging" "default" {
   for_each = toset(local.enabled && length(var.logging) > 0 ? ["enabled"] : [])
 

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket_versioning" "default" {
 }
 
 resource "aws_s3_bucket_logging" "default" {
-  count = local.enabled && try(length(var.logging), 0) > 0 ? 1 : 0
+  for_each = toset(local.enabled && length(var.logging) > 0 ? ["enabled"] : [])
 
   bucket = local.bucket_id
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Replaced the count with a for_each inside `aws_s3_bucket_logging.default`

there's no point in the try since the type is clearly defined as list
## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

When the `bucket_name` within `logging` attribute is dynamically defined, like in the case of referencing a bucket created by terraform for logging

```hcl
  logging = [
    {
      bucket_name = module.logging_bucket.bucket_id
      prefix      = "data/"
    }
  ]
```

 we get this error 
<img width="725" alt="Screenshot 2024-02-05 at 12 50 30" src="https://github.com/cloudposse/terraform-aws-s3-bucket/assets/33103894/42631b61-8629-477c-b629-ff2e6990fb79">

For each can work better in this case and will solve the previous error  
## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
