### PR TITLE
fix: use new destination.bucket key in policy

### DIFF
--- a/replication.tf
+++ b/replication.tf
@@ -1,11 +1,7 @@
-locals {
-  replication_role = format("%s-replication", local.bucket_name)
-}
-
 resource "aws_iam_role" "replication" {
   count = local.replication_enabled ? 1 : 0
 
-  name                 = local.replication_role
+  name                 = format("%s-replication", local.bucket_name)
   assume_role_policy   = data.aws_iam_policy_document.replication_sts[0].json
   permissions_boundary = var.s3_replication_permissions_boundary_arn
 
@@ -32,7 +28,7 @@ data "aws_iam_policy_document" "replication_sts" {
 resource "aws_iam_policy" "replication" {
   count = local.replication_enabled ? 1 : 0
 
-  name   = local.replication_role
+  name   = aws_iam_role.replication[0].name
   policy = data.aws_iam_policy_document.replication[0].json
 
   tags = module.this.tags
@@ -68,6 +64,7 @@ data "aws_iam_policy_document" "replication" {
     resources = toset(concat(
       try(length(var.s3_replica_bucket_arn), 0) > 0 ? ["${var.s3_replica_bucket_arn}/*"] : [],
       [for rule in local.s3_replication_rules : "${rule.destination_bucket}/*" if try(length(rule.destination_bucket), 0) > 0],
+      [for rule in local.s3_replication_rules : "${rule.destination.bucket}/*" if try(length(rule.destination.bucket), 0) > 0],
     ))
   }
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- use new destination.bucket key in policy

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- Support both deprecated `destination_bucket` and new `destination.bucket`
- Previous changes created `destination.bucket` and left `destination_bucket` for backwards compatibility, as stated in variables.tf, and forgot to include the new value in the IAM policy

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Closes #215