### PR TITLE
Minimal provider version for aws_s3_directory_bucket

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 5.28.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## what
Updated AWS provider version for the new resource used in the module aws_s3_directory_bucket

## why
Old provider doesn't support this resource `The provider hashicorp/aws does not support resource type `
 
## references

