### PR TITLE
fix: version pin to avoid hashicorp/aws provider bug

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 4.9.0, < 5.86"
+
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## what
- Stay below a problematic `hasicorp/aws` provider version.
- Hashicorp is working on [patch in 5.86.1](https://github.com/hashicorp/terraform-provider-aws/pull/41315), but until a solution lands well, better to stay below the turbulence.

## why
- The intent is to avoid the `v5.86.0` release, which moved from the Terraform Plugin SDK to Terraform Plugin Framework. 
- The `v5.86.0` code changes the default lifecycle value and going forward requires that you use a 5.86.0 or greater provider.

## references
- Github issue detailing bug, https://github.com/hashicorp/terraform-provider-aws/pull/41296