### PR TITLE
Add S3 Intelligent-Tiering archive configuration support

### DIFF
--- a/examples/complete/intelligent-tiering.us-east-2.tfvars
+++ b/examples/complete/intelligent-tiering.us-east-2.tfvars
@@ -1,0 +1,31 @@
+region = "us-east-2"
+
+namespace = "eg"
+
+stage = "test"
+
+name = "s3-tiering-test"
+
+acl = "private"
+
+force_destroy = true
+
+user_enabled = false
+
+transfer_acceleration_enabled = false
+
+intelligent_tiering_configuration = [
+  {
+    name = "archive-config"
+    tiering = [
+      {
+        access_tier = "ARCHIVE_ACCESS"
+        days        = 180
+      },
+      {
+        access_tier = "DEEP_ARCHIVE_ACCESS"
+        days        = 365
+      },
+    ]
+  }
+]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -44,5 +44,7 @@ module "s3_bucket" {
   cors_configuration               = var.cors_configuration
   website_redirect_all_requests_to = var.website_redirect_all_requests_to
 
+  intelligent_tiering_configuration = var.intelligent_tiering_configuration
+
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -321,3 +321,21 @@ variable "minimum_tls_version" {
   default     = null
   description = "Set the minimum TLS version for in-transit traffic"
 }
+
+variable "intelligent_tiering_configuration" {
+  type = list(object({
+    name   = string
+    status = optional(string, "Enabled")
+    filter = optional(object({
+      prefix = optional(string)
+      tags   = optional(map(string))
+    }))
+    tiering = list(object({
+      access_tier = string
+      days        = number
+    }))
+  }))
+  default     = []
+  description = "A list of S3 Intelligent-Tiering configurations for the bucket."
+  nullable    = false
+}

--- a/lifecycle.tf
+++ b/lifecycle.tf
@@ -56,7 +56,7 @@ locals {
       object_size_greater_than = try(rule.filter_and.object_size_greater_than, null)
       object_size_less_than    = try(rule.filter_and.object_size_less_than, null)
       prefix                   = try(length(rule.filter_and.prefix), 0) == 0 ? null : rule.filter_and.prefix
-      tags                     = try(length(rule.filter_and.tags), 0) == 0 ? {} : rule.filter_and.tags
+      tags                     = try(length(rule.filter_and.tags), 0) == 0 ? null : rule.filter_and.tags
     }
     # We use "!= true" because it covers !null as well as !false, and allows the "null" option to be on the same line.
     expiration = (try(rule.expiration.date, null) == null &&

--- a/main.tf
+++ b/main.tf
@@ -619,7 +619,33 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   }
 }
 
-# Directory Bucket 
+# Intelligent-Tiering Configuration
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_intelligent_tiering_configuration
+resource "aws_s3_bucket_intelligent_tiering_configuration" "default" {
+  for_each = { for config in var.intelligent_tiering_configuration : config.name => config if local.enabled }
+
+  bucket = local.bucket_id
+  name   = each.value.name
+  status = each.value.status
+
+  dynamic "filter" {
+    for_each = each.value.filter != null ? [each.value.filter] : []
+    content {
+      prefix = filter.value.prefix
+      tags   = filter.value.tags
+    }
+  }
+
+  dynamic "tiering" {
+    for_each = each.value.tiering
+    content {
+      access_tier = tiering.value.access_tier
+      days        = tiering.value.days
+    }
+  }
+}
+
+# Directory Bucket
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_directory_bucket
 resource "aws_s3_directory_bucket" "default" {
   count         = var.create_s3_directory_bucket ? 1 : 0

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -584,6 +584,42 @@ func TestExamplesCompleteWithWebsiteRedirectAll(t *testing.T) {
 	assert.NotEmpty(t, output["bucket_website_domain"])
 }
 
+func TestExamplesCompleteWithIntelligentTiering(t *testing.T) {
+	t.Parallel()
+	randID := strings.ToLower(random.UniqueId())
+	attributes := []string{randID}
+
+	rootFolder := "../../"
+	terraformFolderRelativeToRoot := "examples/complete"
+	varFiles := []string{"intelligent-tiering.us-east-2.tfvars"}
+
+	tempTestFolder := testStructure.CopyTerraformFolderToTemp(t, rootFolder, terraformFolderRelativeToRoot)
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: tempTestFolder,
+		Upgrade:      true,
+		VarFiles:     varFiles,
+		Vars: map[string]interface{}{
+			"attributes": attributes,
+		},
+	}
+
+	defer cleanup(t, terraformOptions, tempTestFolder)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	s3BucketId := terraform.Output(t, terraformOptions, "bucket_id")
+
+	expectedS3BucketId := "eg-test-s3-tiering-test-" + attributes[0]
+	assert.Equal(t, expectedS3BucketId, s3BucketId)
+
+	// Re-apply to verify idempotency
+	results := terraform.Apply(t, terraformOptions)
+	re := regexp.MustCompile(`Resources: [^.]+\.`)
+	match := re.FindString(results)
+	assert.Equal(t, "Resources: 0 added, 0 changed, 0 destroyed.", match, "Re-applying the same configuration should not change any resources")
+}
+
 func TestExamplesCompleteDisabled(t *testing.T) {
 	t.Parallel()
 	randID := strings.ToLower(random.UniqueId())

--- a/variables.tf
+++ b/variables.tf
@@ -515,6 +515,28 @@ variable "s3_request_payment_configuration" {
   }
 }
 
+variable "intelligent_tiering_configuration" {
+  type = list(object({
+    name   = string
+    status = optional(string, "Enabled")
+    filter = optional(object({
+      prefix = optional(string)
+      tags   = optional(map(string))
+    }))
+    tiering = list(object({
+      access_tier = string
+      days        = number
+    }))
+  }))
+  default     = []
+  description = <<-EOT
+    A list of S3 Intelligent-Tiering configurations for the bucket.
+    Each configuration controls archive access tiers within the INTELLIGENT_TIERING storage class.
+    `access_tier` must be `ARCHIVE_ACCESS` or `DEEP_ARCHIVE_ACCESS`.
+  EOT
+  nullable    = false
+}
+
 variable "create_s3_directory_bucket" {
   description = "Control the creation of the S3 directory bucket. Set to true to create the bucket, false to skip."
   type        = bool


### PR DESCRIPTION
## What

Add `aws_s3_bucket_intelligent_tiering_configuration` resource and `intelligent_tiering_configuration` variable to support configuring archive access tiers within the INTELLIGENT_TIERING storage class.

## Why

The module already supports `INTELLIGENT_TIERING` as a lifecycle transition storage class, but there's no way to configure the archive access tiers (Archive Access, Deep Archive Access) that control when objects within Intelligent-Tiering are moved to cheaper archive storage. This is needed for cost optimization on buckets with infrequently accessed data.

## Ref

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_intelligent_tiering_configuration