### PR TITLE
feat(outputs): add bucket_hosted_zone_id output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "bucket_website_endpoint" {
   description = "The bucket website endpoint, if website is enabled"
 }
 
+output "bucket_hosted_zone_id" {
+  value       = local.enabled ? one(aws_s3_bucket.default[*].hosted_zone_id) : null
+  description = "The Route 53 Hosted Zone ID for this bucket's region"
+}
+
 output "bucket_id" {
   value       = local.enabled ? local.bucket_id : ""
   description = "Bucket Name (aka ID)"


### PR DESCRIPTION
## what

- [X] Create a new `bucket_hosted_zone_id` output

## why

- Add the ability to output the [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.

## references

- Closes #290 