### PR TITLE
fix(lifecycle): preserve empty-string prefix to silence Invalid Attribute Combination warning

### DIFF
--- a/examples/complete/lifecycle.us-east-2.tfvars
+++ b/examples/complete/lifecycle.us-east-2.tfvars
@@ -42,6 +42,33 @@ lifecycle_configuration_rules = [
       expired_object_delete_marker = null
     }
 
+    # test explicit empty-string prefix (applies to all objects, renders filter { prefix = "" })
+    # Regression test for https://github.com/cloudposse/terraform-aws-s3-bucket/issues/271
+    filter_and = {
+      prefix = ""
+    }
+    id = "emptyprefix"
+    noncurrent_version_expiration = {
+      newer_noncurrent_versions = 2
+      noncurrent_days           = 30
+    }
+    noncurrent_version_transition = []
+    transition = [
+      {
+        days          = 7
+        storage_class = "GLACIER"
+      },
+    ]
+
+  },
+  {
+    abort_incomplete_multipart_upload_days = 1
+    enabled                                = true
+    expiration = {
+      days                         = null
+      expired_object_delete_marker = null
+    }
+
     # test prefix only
     filter_and = {
       prefix = "prefix1"

--- a/lifecycle.tf
+++ b/lifecycle.tf
@@ -45,10 +45,14 @@ locals {
 
     # Due to https://github.com/hashicorp/terraform-provider-aws/issues/23882
     # we have to treat having only the `prefix` set differently than having any other setting.
+    # Use != null (not length > 0) so that prefix = "" is preserved; an empty-string prefix
+    # renders filter { prefix = "" } which applies the rule to all objects without triggering
+    # the "Invalid Attribute Combination" warning in AWS provider < v5.99.0.
+    # See https://github.com/hashicorp/terraform-provider-aws/issues/42112
     filter_prefix_only = (try(rule.filter_and.object_size_greater_than, null) == null &&
       try(rule.filter_and.object_size_less_than, null) == null &&
       try(length(rule.filter_and.tags), 0) == 0 &&
-    try(length(rule.filter_and.prefix), 0) > 0) ? rule.filter_and.prefix : null
+    try(rule.filter_and.prefix, null) != null) ? rule.filter_and.prefix : null
 
     filter_and = (try(rule.filter_and.object_size_greater_than, null) == null &&
       try(rule.filter_and.object_size_less_than, null) == null &&
@@ -95,7 +99,7 @@ locals {
 
     abort_incomplete_multipart_upload_days = rule.abort_incomplete_multipart_upload_days # number
 
-    filter_prefix_only = try(length(rule.prefix), 0) > 0 && try(length(rule.tags), 0) == 0 ? rule.prefix : null
+    filter_prefix_only = try(rule.prefix, null) != null && try(length(rule.tags), 0) == 0 ? rule.prefix : null
     filter_and = try(length(rule.tags), 0) == 0 ? null : {
       object_size_greater_than = null                                   # integer >= 0
       object_size_less_than    = null                                   # integer >= 1
@@ -167,10 +171,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       id     = rule.value.id
       status = rule.value.enabled == true ? "Enabled" : "Disabled"
 
-      # Filter is always required due to https://github.com/hashicorp/terraform-provider-aws/issues/23299
+      # A filter block is always required. Use prefix = "" to apply the rule to all objects.
+      # filter {} (empty) triggers "Invalid Attribute Combination" in AWS provider < v5.99.0;
+      # filter { prefix = "" } is the safe form across all provider versions.
+      # See https://github.com/hashicorp/terraform-provider-aws/issues/42112
       dynamic "filter" {
-        for_each = rule.value.filter_prefix_only == null && rule.value.filter_and == null ? ["empty"] : []
-        content {}
+        for_each = rule.value.filter_prefix_only == null && rule.value.filter_and == null ? ["all"] : []
+        content {
+          prefix = ""
+        }
       }
 
       # When only specifying `prefix`, do not use `and` due to https://github.com/hashicorp/terraform-provider-aws/issues/23882


### PR DESCRIPTION
## what
- Change `length(...) > 0` to `!= null` in both normalization paths so `prefix = ""` is preserved instead of coerced to `null`
- Change the fallback all-objects filter from `content {}` to `content { prefix = "" }` — the safe form across all AWS provider versions
- Add regression fixture case `id = "emptyprefix"` with `filter_and = { prefix = "" }` to `lifecycle.us-east-2.tfvars`

## why
Fixes #271.

When a lifecycle rule has no filter criteria (or explicitly sets `prefix = ""`), the normalization converts it to `null` via `try(length(...prefix), 0) > 0`. With both `filter_prefix_only` and `filter_and` null, the module renders `filter {}`. In AWS provider ≥ v5.94 this produces:

```
Warning: Invalid Attribute Combination — This will be an error in a future version of the provider
```

The `filter {}` form was fixed upstream in provider v5.99.0, but callers on older v5.x providers continue to see the warning. The safe form across **all provider versions** is `filter { prefix = "" }`:

| Provider version | `filter {}` | `filter { prefix = "" }` |
|---|---|---|
| v5.94–v5.98 | ⚠️ warns | ✅ no warning |
| v5.99+ | ✅ fixed | ✅ no warning |
| v6.x | ✅ valid (`WarnAtMostOneOfChildren`) | ✅ valid — provider explicitly treats `prefix = ""` as nil/empty ([source](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/s3/bucket_lifecycle_configuration.go)) |

Changing `> 0` to `!= null` also fixes a semantic bug: callers who explicitly pass `filter_and = { prefix = "" }` to target all objects now get `filter { prefix = "" }` instead of silently falling back to an empty filter.

## reviewer guide
1. **`lifecycle.tf` line ~51** (`normalized_lifecycle_configuration_rules`) — `try(length(rule.filter_and.prefix), 0) > 0` → `try(rule.filter_and.prefix, null) != null`: preserves `""` through normalization
2. **`lifecycle.tf` line ~99** (`normalized_lifecycle_rules`, legacy `lifecycle_rules` path) — same one-line change
3. **`lifecycle.tf` lines ~171-177** — `content {}` → `content { prefix = "" }`; updated comment from #23299 to #42112
4. **`examples/complete/lifecycle.us-east-2.tfvars`** — new `emptyprefix` rule between `nofilter` and `prefix1` as regression coverage

## test plan

Tested locally prior to opening this PR:

- [x] `terraform fmt -recursive -check` passes
- [x] `tofu fmt -recursive -check` passes
- [x] `terraform validate` passes on root module and `examples/complete`
- [x] `tofu validate` passes on root module and `examples/complete`
- [x] `go test -run TestExamplesCompleteWithLifecycleRules` — plan ran successfully; no `Invalid Attribute Combination` warning on any filter block; `nofilter` and `emptyprefix` rules both render `filter { prefix = "" }` (shown as `# (1 unchanged attribute hidden)` in plan diff since Terraform suppresses empty-string values); `prefix1` renders `filter { prefix = "prefix1" }` unchanged; `prefix2`/`big` render `filter { and { ... } }` unchanged — full `apply` was blocked by an org-level SCP on the test account (`s3:CreateBucket` denied), not by the module change
- [ ] Reviewer: confirm no `Invalid Attribute Combination` warning on AWS provider v5.94–v5.98 after apply